### PR TITLE
Adds env parser to accomandate extra ENV variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ jspm_packages
 # private directory
 .private
 
+# lock file for packages
+package-lock.json
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ export GITHUB_BUILD_COMMENT="go codebuild go"  # Case-insensitive string that wi
 export CB_EXTERNAL_BUILDSPEC=false # Set to true if repo for the CodeBuild project is different from repo where webhook is created
 export CB_GIT_REPO_ENV=REPO_TO_BUILD # Name of ENV variable CodeBuild project uses to know which repo to clone. Use with CB_EXTERNAL_BUILDSPEC.
 export CB_GIT_REF_ENV=REF_TO_BUILD # Name of ENV variable CodeBuild project uses to know which git ref to checkout. Use with CB_EXTERNAL_BUILDSPEC.
+export CB_ENV # key=value pairs of any extra Environment Variables to be included in the CodeBuild jobs. Example: CB_ENV="FOO=bar;ABC=123"
 ```
 
 5.  Run `serverless deploy`

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ custom:
     cbExternalBuildspec: "false"
     cbGitRepoEnv: ""
     cbGitRefEnv: ""
+    cbEnv: ""
   parameters:
     CbBuildProject:
       Type: String
@@ -53,6 +54,10 @@ custom:
       Type: String
       Default: ${env:CB_GIT_REF_ENV, self:custom.github-webhook.cbGitRefEnv}
       Description: (Optional) Name of ENV variable that your CodeBuild project uses to know which git ref to checkout. For use with CB_EXTERNAL_BUILDSPEC.
+    CbEnv:
+      Type: String
+      Default: ${env:CB_ENV, self:custom.github-webhook.cbEnv}
+      Description: (Optional) Extra ENV variables will be pass to the CodeBuild job, supporting (CB_ENV="FOO=bar;ABC=123") .
     SsmGithubUsername:
       Type: String
       Default: ${env:SSM_GITHUB_USERNAME}
@@ -107,6 +112,8 @@ provider:
       Ref: CbGitRepoEnv
     CB_GIT_REF_ENV:
       Ref: CbGitRefEnv
+    CB_ENV:
+      Ref: CbEnv
     SSM_GITHUB_USERNAME:
       Ref: SsmGithubUsername
     SSM_GITHUB_ACCESS_TOKEN:


### PR DESCRIPTION
* Allows passing extra ENV variables to the CI build job using `CB_ENV`. Example of the setting extra variables: `CB_ENV="foo=bar;abc=123"`